### PR TITLE
Issue1 - improved hadoop dependency filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     </license>
   </licenses>
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <mvn.plugin.version>2.0.9</mvn.plugin.version>
     <git.url>http://github.com/akkumar/maven-hadoop.git</git.url>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.0.2</version>
+        <version>2.4</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>
@@ -61,7 +61,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.0-beta-7</version>
+        <version>2.2.2</version>
         <dependencies>
           <dependency>
             <groupId>org.apache.maven.scm</groupId>
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>1.4</version>
+      <version>2.3</version>
     </dependency>
   </dependencies>
 
@@ -137,7 +137,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.0-alpha-4</version>
+            <version>1.4</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.github.maven-hadoop.plugin</groupId>
   <artifactId>maven-hadoop-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>0.20.2-SNAPSHOT</version>
+  <version>1.0.2-SNAPSHOT</version>
   <name>Maven Plugin for Hadoop </name>
   <description>Maven plugin for Hadoop</description>
   <url>http://github.com/akkumar/maven-hadoop/tree/master</url>

--- a/src/main/java/com/github/hadoop/maven/plugin/PackMojo.java
+++ b/src/main/java/com/github/hadoop/maven/plugin/PackMojo.java
@@ -181,18 +181,22 @@ public class PackMojo extends AbstractMojo {
    */
   private Set<Artifact> filterArtifacts(Set<Artifact> artifacts) {
     List<String> hadoopArtifactIds = getHadoopArtifactIds();
-    getLog().info("Hadoop Artifact Ids  are " + hadoopArtifactIds);
+    getLog().info("Hadoop Artifact Ids are " + hadoopArtifactIds);
     Set<Artifact> output = new HashSet<Artifact>();
     for (final Artifact inputArtifact : artifacts) {
       final String name = inputArtifact.getArtifactId();
       final String group = inputArtifact.getGroupId();
-      if (group.startsWith("org.apache") && name.startsWith("hadoop") 
-          || name.startsWith("jsp-")
-          || hadoopArtifactIds.contains(name)) {
-        getLog().info(
-            "Ignoring " + inputArtifact
-                + " because of that being a hadoop dependency ");
-        continue; // skip other dependencies in hadoop cp as well.
+      if (hadoopArtifactIds.contains(name)) {
+        getLog().info("Ignoring " + inputArtifact 
+            + " (it is a hadoop dependency)");
+      }
+      else if (group.startsWith("org.apache") && name.startsWith("hadoop")) {
+        getLog().info("Ignoring " + inputArtifact 
+            + " (`it is in 'org.apache' and starts with 'hadoop')");
+      }
+      else if (name.startsWith("jsp-")) {
+        getLog().info("Ignoring " + inputArtifact 
+            + " (it starts with 'jsp-')");
       } else {
         output.add(inputArtifact);
       }

--- a/src/main/java/com/github/hadoop/maven/plugin/PackMojo.java
+++ b/src/main/java/com/github/hadoop/maven/plugin/PackMojo.java
@@ -185,7 +185,9 @@ public class PackMojo extends AbstractMojo {
     Set<Artifact> output = new HashSet<Artifact>();
     for (final Artifact inputArtifact : artifacts) {
       final String name = inputArtifact.getArtifactId();
-      if (name.startsWith("hadoop") || name.startsWith("jsp-")
+      final String group = inputArtifact.getGroupId();
+      if (group.startsWith("org.apache") && name.startsWith("hadoop") 
+          || name.startsWith("jsp-")
           || hadoopArtifactIds.contains(name)) {
         getLog().info(
             "Ignoring " + inputArtifact

--- a/src/main/java/com/github/hadoop/maven/plugin/PackMojo.java
+++ b/src/main/java/com/github/hadoop/maven/plugin/PackMojo.java
@@ -192,7 +192,7 @@ public class PackMojo extends AbstractMojo {
       }
       else if (group.startsWith("org.apache") && name.startsWith("hadoop")) {
         getLog().info("Ignoring " + inputArtifact 
-            + " (`it is in 'org.apache' and starts with 'hadoop')");
+            + " (it is in 'org.apache' and starts with 'hadoop')");
       }
       else if (name.startsWith("jsp-")) {
         getLog().info("Ignoring " + inputArtifact 

--- a/src/main/java/com/github/hadoop/maven/plugin/PackMojo.java
+++ b/src/main/java/com/github/hadoop/maven/plugin/PackMojo.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Properties;
 import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
@@ -94,13 +93,6 @@ public class PackMojo extends AbstractMojo {
    * @readonly
    */
   protected MavenProject project;
-
-  /**
-   * Hadoop Configuration properties
-   * 
-   * @parameter
-   */
-  private Properties hadoopConfiguration;
 
   /**
    * @parameter expression="${project.build.directory}/hadoop-deploy"
@@ -226,30 +218,6 @@ public class PackMojo extends AbstractMojo {
       }
     }
     return outputJars;
-  }
-
-  /**
-   * Retrieve the project dependencies.
-   * 
-   * @param scope
-   *          Scope of the dependency to resolve to .
-   * @return
-   */
-  @SuppressWarnings("unchecked")
-  private List<File> getScopedDependencies(final String scope) {
-    List<File> jarDependencies = new ArrayList<File>();
-    final Set<Artifact> artifacts = project.getDependencyArtifacts();
-    for (Artifact artifact : artifacts) {
-      if ("jar".equals(artifact.getType())) {
-        File file = artifact.getFile();
-        if (file != null && file.exists()) {
-          jarDependencies.add(file);
-        } else {
-          getLog().warn("Dependency file not found: " + artifact);
-        }
-      }
-    }
-    return jarDependencies;
   }
 
   private File packToJar(final File jarRootDir) throws FileNotFoundException,


### PR DESCRIPTION
These commits address issue 1 by requiring that the group be "org.apache" when using the "starts with 'hadoop'" filter.  I'm sorry to bundle plugin version increases and dependency increases along with this change, but I couldn't install the plugin locally before applying some of these updates (I originally had them as separate forks).

I also increased the version number to the version of Hadoop I have been using, since it is much newer than the previous version of the plugin.

I also changed the code to provide more detailed messages for why a dependency is ignored.
